### PR TITLE
Hotfix/PDF Importer

### DIFF
--- a/supabase/app/api/import/extract/route.ts
+++ b/supabase/app/api/import/extract/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: Request) {
     const arrayBuffer = await file.arrayBuffer();
     rawText = await extractText(arrayBuffer);
   } catch (err) {
-    console.error('[extract] pdf-parse extraction failed:', (err as Error).message, filename);
+    console.error('[extract] pdf-parse extraction failed:', err, filename);
     return Response.json(
       { error: 'An error occurred during extraction. Please try again.' },
       { status: 500 }
@@ -50,7 +50,7 @@ export async function POST(request: Request) {
     const draft = await extractRecipe(rawText, filename);
     return Response.json(draft);
   } catch (err) {
-    console.error('[extract] Claude extraction failed:', (err as Error).message, filename);
+    console.error('[extract] Claude extraction failed:', err, filename);
     return Response.json(
       { error: 'An error occurred during extraction. Please try again.' },
       { status: 500 }

--- a/supabase/app/api/import/extract/route.ts
+++ b/supabase/app/api/import/extract/route.ts
@@ -39,7 +39,7 @@ export async function POST(request: Request) {
   } catch (err) {
     console.error('[extract] pdf-parse extraction failed:', err, filename);
     return Response.json(
-      { error: 'An error occurred during extraction. Please try again.' },
+      { error: 'pdf-parse failed', detail: String(err), stack: (err as Error)?.stack },
       { status: 500 }
     );
   }
@@ -59,7 +59,7 @@ export async function POST(request: Request) {
   } catch (err) {
     console.error('[extract] Claude extraction failed:', err, filename);
     return Response.json(
-      { error: 'An error occurred during extraction. Please try again.' },
+      { error: 'Claude failed', detail: String(err), stack: (err as Error)?.stack },
       { status: 500 }
     );
   }

--- a/supabase/app/api/import/extract/route.ts
+++ b/supabase/app/api/import/extract/route.ts
@@ -4,10 +4,12 @@ import { extractRecipe } from '@/lib/recipe-extractor';
 const MAX_SIZE_BYTES = 10 * 1024 * 1024;
 
 export async function POST(request: Request) {
+  console.log('[extract] POST started');
   let formData: FormData;
 
   try {
     formData = await request.formData();
+    console.log('[extract] formData parsed');
   } catch {
     return Response.json({ error: 'Invalid form data.' }, { status: 400 });
   }
@@ -26,11 +28,14 @@ export async function POST(request: Request) {
   }
 
   const filename = file.name;
+  console.log('[extract] file:', filename, file.size);
   let rawText: string;
 
   try {
     const arrayBuffer = await file.arrayBuffer();
+    console.log('[extract] arrayBuffer obtained, starting pdf extraction');
     rawText = await extractText(arrayBuffer);
+    console.log('[extract] pdf extraction complete, text length:', rawText.length);
   } catch (err) {
     console.error('[extract] pdf-parse extraction failed:', err, filename);
     return Response.json(
@@ -46,8 +51,10 @@ export async function POST(request: Request) {
     );
   }
 
+  console.log('[extract] starting Claude extraction');
   try {
     const draft = await extractRecipe(rawText, filename);
+    console.log('[extract] Claude extraction complete');
     return Response.json(draft);
   } catch (err) {
     console.error('[extract] Claude extraction failed:', err, filename);

--- a/supabase/app/api/import/extract/route.ts
+++ b/supabase/app/api/import/extract/route.ts
@@ -4,12 +4,10 @@ import { extractRecipe } from '@/lib/recipe-extractor';
 const MAX_SIZE_BYTES = 10 * 1024 * 1024;
 
 export async function POST(request: Request) {
-  console.log('[extract] POST started');
   let formData: FormData;
 
   try {
     formData = await request.formData();
-    console.log('[extract] formData parsed');
   } catch {
     return Response.json({ error: 'Invalid form data.' }, { status: 400 });
   }
@@ -28,20 +26,14 @@ export async function POST(request: Request) {
   }
 
   const filename = file.name;
-  console.log('[extract] file:', filename, file.size);
   let rawText: string;
 
   try {
     const arrayBuffer = await file.arrayBuffer();
-    console.log('[extract] arrayBuffer obtained, starting pdf extraction');
     rawText = await extractText(arrayBuffer);
-    console.log('[extract] pdf extraction complete, text length:', rawText.length);
   } catch (err) {
     console.error('[extract] pdf-parse extraction failed:', err, filename);
-    return Response.json(
-      { error: 'pdf-parse failed', detail: String(err), stack: (err as Error)?.stack },
-      { status: 500 }
-    );
+    return Response.json({ error: 'Failed to extract text from PDF.' }, { status: 500 });
   }
 
   if (!rawText || !rawText.trim()) {
@@ -51,16 +43,11 @@ export async function POST(request: Request) {
     );
   }
 
-  console.log('[extract] starting Claude extraction');
   try {
     const draft = await extractRecipe(rawText, filename);
-    console.log('[extract] Claude extraction complete');
     return Response.json(draft);
   } catch (err) {
     console.error('[extract] Claude extraction failed:', err, filename);
-    return Response.json(
-      { error: 'Claude failed', detail: String(err), stack: (err as Error)?.stack },
-      { status: 500 }
-    );
+    return Response.json({ error: 'Failed to extract recipe from PDF.' }, { status: 500 });
   }
 }

--- a/supabase/lib/pdf.ts
+++ b/supabase/lib/pdf.ts
@@ -1,4 +1,11 @@
 export async function extractText(arrayBuffer: ArrayBuffer): Promise<string> {
+  // pdfjs-dist v5 (used by pdf-parse v2) references DOMMatrix at module init;
+  // Node.js doesn't provide it, so we stub it for text-only extraction.
+  if (typeof DOMMatrix === 'undefined') {
+    (globalThis as unknown as Record<string, unknown>).DOMMatrix = class DOMMatrix {
+      constructor(_init?: string | number[]) {}
+    };
+  }
   const { PDFParse } = await import('pdf-parse');
   const parser = new PDFParse({ data: new Uint8Array(arrayBuffer) });
   const result = await parser.getText();

--- a/supabase/lib/pdf.ts
+++ b/supabase/lib/pdf.ts
@@ -1,6 +1,5 @@
-import { PDFParse } from 'pdf-parse';
-
 export async function extractText(arrayBuffer: ArrayBuffer): Promise<string> {
+  const { PDFParse } = await import('pdf-parse');
   const parser = new PDFParse({ data: new Uint8Array(arrayBuffer) });
   const result = await parser.getText();
   return result.text;

--- a/supabase/next.config.ts
+++ b/supabase/next.config.ts
@@ -5,6 +5,11 @@ const nextConfig: NextConfig = {
     root: __dirname,
   },
   serverExternalPackages: ['pdf-parse', 'pdfjs-dist'],
+  outputFileTracingIncludes: {
+    '/api/import/extract': [
+      './node_modules/.pnpm/pdfjs-dist*/node_modules/pdfjs-dist/legacy/build/**/*',
+    ],
+  },
 };
 
 export default nextConfig;

--- a/supabase/next.config.ts
+++ b/supabase/next.config.ts
@@ -7,7 +7,7 @@ const nextConfig: NextConfig = {
   serverExternalPackages: ['pdf-parse', 'pdfjs-dist'],
   outputFileTracingIncludes: {
     '/api/import/extract': [
-      './node_modules/.pnpm/pdfjs-dist*/node_modules/pdfjs-dist/legacy/build/**/*',
+      './node_modules/.pnpm/pdfjs-dist*/node_modules/pdfjs-dist/legacy/build/pdf.worker.mjs',
     ],
   },
 };

--- a/supabase/pnpm-lock.yaml
+++ b/supabase/pnpm-lock.yaml
@@ -375,16 +375,34 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
   '@napi-rs/canvas-android-arm64@0.1.80':
     resolution: {integrity: sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
 
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@napi-rs/canvas-darwin-arm64@0.1.80':
     resolution: {integrity: sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
     os: [darwin]
 
   '@napi-rs/canvas-darwin-x64@0.1.80':
@@ -393,14 +411,32 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
   '@napi-rs/canvas-linux-arm-gnueabihf@0.1.80':
     resolution: {integrity: sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@napi-rs/canvas-linux-arm64-gnu@0.1.80':
     resolution: {integrity: sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -411,14 +447,32 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.80':
     resolution: {integrity: sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
 
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@napi-rs/canvas-linux-x64-gnu@0.1.80':
     resolution: {integrity: sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -429,11 +483,27 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@napi-rs/canvas-win32-x64-msvc@0.1.80':
     resolution: {integrity: sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/canvas@0.1.80':
     resolution: {integrity: sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==}
@@ -2365,34 +2435,82 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
   '@napi-rs/canvas-android-arm64@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
     optional: true
 
   '@napi-rs/canvas-darwin-arm64@0.1.80':
     optional: true
 
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
   '@napi-rs/canvas-darwin-x64@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
     optional: true
 
   '@napi-rs/canvas-linux-arm-gnueabihf@0.1.80':
     optional: true
 
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
   '@napi-rs/canvas-linux-arm64-gnu@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
     optional: true
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.80':
     optional: true
 
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
     optional: true
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.80':
     optional: true
 
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
   '@napi-rs/canvas-linux-x64-musl@0.1.80':
     optional: true
 
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
   '@napi-rs/canvas-win32-x64-msvc@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
     optional: true
 
   '@napi-rs/canvas@0.1.80':
@@ -3808,7 +3926,7 @@ snapshots:
 
   pdfjs-dist@5.4.296:
     optionalDependencies:
-      '@napi-rs/canvas': 0.1.80
+      '@napi-rs/canvas': 0.1.100
 
   picocolors@1.1.1: {}
 


### PR DESCRIPTION
## Description

This PR fixes breaking errors in the recipe import form caused by the `pdf-parse` plugin.

###### Root Cause Notes
`pdf-parse` v2 uses pdfjs-dist v5 internally. `pdfjs-dist` v5 is a browser-first library with two incompatibilities in Node.js/Vercel serverless:
1. It references `DOMMatrix` (a browser-only Web API) at module initialization time
2. Its "fake worker" mechanism dynamically loads `pdf.worker.mjs` at runtime, which Vercel's file tracer never picks up because it only follows static imports

###### Related Updates
- Updates `import { PDFParse } from 'pdf-parse'` (static, module-level) to `const { PDFParse } = await import('pdf-parse')` (dynamic, deferred to request time) which prevents the module-level `DOMMatrix` reference from crashing the route before any handler runs
- Adds a minimal `DOMMatrix` stub on `globalThis` before the dynamic import (satisfies `pdfjs-dist`'s module initialization without any browser environment)
- Adds `outputFileTracingIncludes` to `next.config` to deploy pdf.worker.mjs (Next.js's file tracer only follows static imports, so the worker file was missing from production bundles)